### PR TITLE
Update Trivy from 0.36.0 to 0.47.0

### DIFF
--- a/build/images/Dockerfile.package
+++ b/build/images/Dockerfile.package
@@ -16,7 +16,7 @@ FROM registry.access.redhat.com/ubi8:8.7
 
 ENV BUILDAH_VERSION=1.29 \
     SKOPEO_VERSION=1.11 \
-    TRIVY_VERSION=0.36.0
+    TRIVY_VERSION=0.47.0
 
 COPY --from=builder /usr/local/bin/ods-package-image /usr/local/bin/ods-package-image
 


### PR DESCRIPTION
Many things have improved between those versions, see https://github.com/aquasecurity/trivy/releases.

In particular, the changes to the Java scanning as e.g. described in https://github.com/aquasecurity/trivy/discussions/3719 may help in situations where we have seen timeouts.